### PR TITLE
lighter base image for java

### DIFF
--- a/images/java/Dockerfile
+++ b/images/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-slim
+FROM openjdk:8u312-slim
 
 # Create the dummy user
 RUN useradd --create-home --shell /bin/bash execution_user


### PR DESCRIPTION
Changed base image from openjdk:16-slim to openjdk:8u312-slim
Lighter base image